### PR TITLE
совместимость с php 8

### DIFF
--- a/src/Sign.php
+++ b/src/Sign.php
@@ -223,13 +223,12 @@ class Sign
 
         $this->validateErrorString(openssl_error_string());
 
-        if (!is_resource($privateKey)) {
-            return false;
+        if (is_resource($privateKey) || is_object($privateKey)) {
+            $this->privateKey = $privateKey;
+            return $this->privateKey;
         }
 
-        $this->privateKey = $privateKey;
-
-        return $this->privateKey;
+        return false;
     }
 
     /**


### PR DESCRIPTION
изменены условия проверки результата публичного ключа, с 8 версии результатом является класс OpenSSLAsymmetricKey а не ресурс